### PR TITLE
Update Freesia.java

### DIFF
--- a/Freesia-Velocity/src/main/java/meow/kikir/freesia/velocity/Freesia.java
+++ b/Freesia-Velocity/src/main/java/meow/kikir/freesia/velocity/Freesia.java
@@ -38,7 +38,7 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;


### PR DESCRIPTION
To fix this error on Velocity-CTD
```
java.lang.NullPointerException: Cannot invoke "com.velocitypowered.api.proxy.ProxyServer.sendMessage(net.kyori.adventure.text.Component)" because "meow.kikir.freesia.velocity.Freesia.PROXY_SERVER" is null
	at meow.kikir.freesia.velocity.Freesia.printLogo(Freesia.java:68) ~[?:?]
	at meow.kikir.freesia.velocity.Freesia.onProxyStart(Freesia.java:86) ~[?:?]
	at meow.kikir.freesia.velocity.Lmbda$46.execute(Unknown Source) ~[?:?]
	at com.velocitypowered.proxy.event.UntargetedEventHandler$VoidHandler.lambda$buildHandler$0(UntargetedEventHandler.java:56) ~[velocity-proxy-3.4.0-SNAPSHOT-all.jar:3.4.0-SNAPSHOT (git-a66466c4)]
	at com.velocitypowered.proxy.event.VelocityEventManager.fire(VelocityEventManager.java:552) ~[velocity-proxy-3.4.0-SNAPSHOT-all.jar:3.4.0-SNAPSHOT (git-a66466c4)]
	at com.velocitypowered.proxy.event.VelocityEventManager.lambda$fire$5(VelocityEventManager.java:541) ~[velocity-proxy-3.4.0-SNAPSHOT-all.jar:3.4.0-SNAPSHOT (git-a66466c4)]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1447) [?:?]
```